### PR TITLE
Mobile optimization

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -40,12 +40,13 @@
 #glass {
   background: #282c34;
   min-height: 90vh;
-  max-height: 600px;
+  max-height: 500px;
   overflow-y: scroll;
 }
 
 #page {
   background: rgb(12, 12, 12);
+  min-height: 100vh;
 }
 
 #choice {

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -39,7 +39,9 @@
 
 #glass {
   background: #282c34;
-  min-height: 100vh;
+  min-height: 90vh;
+  max-height: 600px;
+  overflow-y: scroll;
 }
 
 #page {

--- a/client/src/modules/AdminVendingMachine/AdminVendingMachine.js
+++ b/client/src/modules/AdminVendingMachine/AdminVendingMachine.js
@@ -93,7 +93,7 @@ const AdminVendingMachine = () => {
   };
 
   return (
-    <div id="page">
+    <div id="page" className="container-fluid">
       <div className="row App-header">
         <div className="col-sm-4" />
         <div className="col-sm-4">
@@ -137,7 +137,7 @@ const AdminVendingMachine = () => {
         <div style={{marginTop: "15px"}} className="col-sm-4 row">
           <div className="col-1" />
           <div className="col-10" >
-            <Box className="text-center" sx={{paddingTop: "10px", paddingBottom: "10px", paddingLeft: "5px", paddingRight: "5px", background: "white"}}>
+            <Box className="text-center" sx={{paddingTop: "10px", paddingBottom: "10px", paddingLeft: "5px", paddingRight: "5px", background: "white", minHeight: "150px"}}>
               <div style={{color: "black"}} className="row">
                 {soda === false ? <h1>Select a soda</h1> : <h1>{soda.productName}</h1>}
               </div>

--- a/client/src/modules/AdminVendingMachine/AdminVendingMachine.js
+++ b/client/src/modules/AdminVendingMachine/AdminVendingMachine.js
@@ -102,7 +102,7 @@ const AdminVendingMachine = () => {
         <div className="col-sm-4" />
       </div>
       <div className="row">
-        <div className="col-md-8 col-sm-8 col-8 row">  
+        <div style={{marginTop: "15px"}} className="col-sm-8 row">  
           <div className="col-1" />
           <div className="col-10" id="glass">
             {loading ? <CircularProgress /> : 
@@ -134,9 +134,9 @@ const AdminVendingMachine = () => {
           </div>
           <div className="col-1" />
         </div>
-        <div className="col-md-4 col-sm-4 col-4">
+        <div style={{marginTop: "15px"}} className="col-sm-4 row">
           <div className="col-1" />
-          <div className="col-10 row" >
+          <div className="col-10" >
             <Box className="text-center" sx={{paddingTop: "10px", paddingBottom: "10px", paddingLeft: "5px", paddingRight: "5px", background: "white"}}>
               <div style={{color: "black"}} className="row">
                 {soda === false ? <h1>Select a soda</h1> : <h1>{soda.productName}</h1>}

--- a/client/src/modules/SodaCard/SodaCard.js
+++ b/client/src/modules/SodaCard/SodaCard.js
@@ -52,7 +52,7 @@ const card = (productName, description, cost, code, remaining, max, admin, sendR
 
 const SodaCard = (props) => {
   return (
-      <Card style={{height:"250px", margin: "5px", boxShadow: `0 0 10px 2px black`}} variant="outlined">
+      <Card style={{height:"250px", margin: "3px", boxShadow: `0 0 10px 2px black`}} variant="outlined">
         {card(props.productName, props.description, props.cost, props.code, props.remaining, props.max, props.admin, props.callbackFunction)}
       </Card>
   );

--- a/client/src/modules/VendingMachine/VendingMachine.js
+++ b/client/src/modules/VendingMachine/VendingMachine.js
@@ -198,7 +198,7 @@ const VendingMachine = () => {
         <div className="col-sm-4" />
       </div>
       <div className="row">
-        <div className="col-md-8 col-sm-8 col-8 row">  
+        <div style={{marginTop: "15px"}} className="col-sm-8 row">  
           <div className="col-1" />
           <div className="col-10" id="glass">
             {loading ? <CircularProgress /> : 
@@ -229,12 +229,11 @@ const VendingMachine = () => {
           </div>
           <div className="col-1" />
         </div>
-        <div className="col-md-4 col-sm-4 col-4">
+        <div style={{marginTop: "15px"}} className="col-sm-4 row">
           <div className="col-1" />
           <div className="col-10" >
             <Box className="text-center userBox" sx={{paddingTop: "10px", paddingBottom: "10px", paddingLeft: "5px", paddingRight: "5px"}}>
               <TextField id="choice" onChange={handleChoiceChange} disabled variant="outlined" value={choice} name="choice" />
-              
               <div style={{marginTop: "10px"}} className="keypad row">
                 <div className="col-4">
                   <div className="row">

--- a/client/src/modules/VendingMachine/VendingMachine.js
+++ b/client/src/modules/VendingMachine/VendingMachine.js
@@ -189,8 +189,8 @@ const VendingMachine = () => {
   };
 
   return (
-    <div id="page">
-      <div className="row App-header">
+    <div id="page" className="container-fluid">
+      <div className="App-header">
         <div className="col-sm-4" />
         <div className="col-sm-4">
           <h1>ColaCo</h1>


### PR DESCRIPTION
I made it more mobile-friendly by adjusting the grid/bootstrap layout. When the screen becomes small enough, it will place the keypad at the bottom. To make sure the user doesn't have to scroll through a copious amount of sodas to reach the keypad, I made the "glass" scrollable. I also fixed the small white spaces that were at the bottom and right of the screen by using Bootstrap's container-fluid.